### PR TITLE
Fix import in DataTransformation.py

### DIFF
--- a/resource/python/DataTransformation.py
+++ b/resource/python/DataTransformation.py
@@ -1,5 +1,4 @@
 import dataiku
-from dataiku import os
 import json
 import os
 import logging


### PR DESCRIPTION
Remove 'from dataiku import os'

This line, while incorrect apparently passes testing in DSS 6.x. DSS 7.x throws the expected parsing error.